### PR TITLE
Remove autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Now open Vim and run `:BundleInstall`
 
 ## Other Additions
 
-* Vim will autosave after every keystroke. This will not trigger syntax highlighting and other
-events looking at the BufWrite autocommand as those will still require manually saving.
 * Manually saving a buffer will remove trailing whitespace automatically. Note that this should not
 be run on the ~/.vim/vimrc file because there is a required trailing whitespace character.
 

--- a/bundles.vimrc
+++ b/bundles.vimrc
@@ -25,7 +25,6 @@ Plugin 'tpope/vim-abolish'
 
 " Utilities
 Plugin 'bling/vim-airline'
-Plugin '907th/vim-auto-save'
 Plugin 'kien/ctrlp.vim'
 Plugin 'rgarver/Kwbd.vim'
 Plugin 'embear/vim-localvimrc'

--- a/default.vimrc
+++ b/default.vimrc
@@ -131,9 +131,6 @@ map <leader><leader> :ZoomWin<CR>
 " Delete buffer without closing window
 nnoremap <silent> <leader>bd :Kwbd<CR>
 
-" enable AutoSave on Vim startup
-let g:auto_save = 1
-
 " CTags
 map <leader>rt :!ctags --extra=+f --exclude=tmp --exclude=node_modules -R * <CR><CR>
 map <leader>lt :TlistToggle<CR>


### PR DESCRIPTION
The autosave feature is pretty aggressive. It triggers syntax highlighting per keystroke and whitespace gets trimmed on each save ... so typing spaces is difficult.
![autosave-fail](https://cloud.githubusercontent.com/assets/625787/7400527/7b0f420a-ee72-11e4-90e9-2981aa813c16.gif)

All hail `:w`
