### PR TITLE
Pare back clj customizations.

### DIFF
--- a/after/ftplugin/clojure.vim
+++ b/after/ftplugin/clojure.vim
@@ -1,1 +1,1 @@
-setlocal lispwords+=->,->>,do,match,describe,context,it,around
+setlocal lispwords+=do,match,describe,context,it,around

--- a/custom-clojure.vimrc
+++ b/custom-clojure.vimrc
@@ -1,31 +1,7 @@
 nnoremap <leader>E :%Eval<CR>
+nnoremap <leader>R :Require<CR>
 
 " Rainbow parentheses always on
 au BufEnter *.clj RainbowParenthesesToggleAll
-
-" Parse implementation namespace from the first line in the test file
-" Example:
-"   (ns foo-app.handler-spec)
-"   => foo-app.handler
-function! s:GetNamespaceFromTest()
-  let regex = "(ns\\s\\+\\(.*\\)-\\(spec\\|test\\)"
-  let location = 1
-  let line = getline(location)
-  return substitute(line, regex, "\\1", "")
-endfunction
-
-" Reload implementation namespace and eval test file
-function! RunTestWithReload()
-  let namespace = s:GetNamespaceFromTest()
-  execute 'Require ' . namespace
-  %Eval
-endfunction
-
-function! s:AutoReload()
-  Require
-endfunction
-
-autocmd BufRead *_spec.clj,*_test.clj nnoremap <buffer> <leader>t :call RunTestWithReload()<CR>
-autocmd BufWritePre *.clj :call s:AutoReload()
 
 let tlist_clojure_settings = 'lisp;f:function'


### PR DESCRIPTION
* Remove reloading namespaces as it's a pain
* Remove test customizations as they're not used
* Don't line break thread macros too much